### PR TITLE
Improve code block appearance

### DIFF
--- a/_layouts/base.liquid
+++ b/_layouts/base.liquid
@@ -14,7 +14,7 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
   <script src="https://kit.fontawesome.com/{{ site.fontawesome.id }}.js" crossorigin="anonymous"></script>
   <link href="/vendor/css/academicons.min.css" rel="stylesheet">
-  <link href="/vendor/pygments/default.css" rel="stylesheet">
+  <link href="/vendor/pygments/monokai.css" rel="stylesheet">
   <link href="/css/bamos.css" rel="stylesheet">
   <link href="/css/updates.css" rel="stylesheet">
   <link href="/css/sharingbuttons.css" rel="stylesheet">
@@ -155,8 +155,8 @@
             // Find the element that matches the hash
             const targetElement = document.querySelector(hash);
             if (targetElement) {
-                // Add the highlight class to the element
-                targetElement.classList.add('highlight');
+                // Add the section-highlight class to the element
+                targetElement.classList.add('section-highlight');
                 
                 // If there are collapsible sections related to this hash, open them
                 const relatedSections = ['lessons', 'practical', 'objective'];
@@ -169,7 +169,7 @@
 
                 // Set a timeout to remove the highlight after 5 seconds
                 setTimeout(() => {
-                    targetElement.classList.remove('highlight');
+                    targetElement.classList.remove('section-highlight');
                 }, 5000); // 5000 milliseconds = 5 seconds
             }
         }

--- a/css/pgupta.css
+++ b/css/pgupta.css
@@ -165,7 +165,8 @@ a.button1:hover {
   }
 }
 
-.highlight {
+/* Used to highlight sections referenced by URL hashes */
+.section-highlight {
   background-color: #E0F2F1; /* Pale green for a soothing background */
   padding: 10px; /* Adds space around the text */
   border-radius: 8px; /* Smooth rounded corners */
@@ -176,7 +177,7 @@ a.button1:hover {
   font-weight: bold;
   color: #005662; /* A darker shade that contrasts well with a pale green background */
   animation: fadeIn 1s ease-in-out;
-  scroll-margin-top: 100px; 
+  scroll-margin-top: 100px;
 }
 
 
@@ -370,6 +371,27 @@ a.button1:hover {
 .navbar-nav .social-icon:hover .ai-google-scholar {
   color: #3367d6;
   transform: scale(1.1);
+}
+
+/* --------------------------------------------- */
+/* Code block styling                            */
+/* --------------------------------------------- */
+
+/* Outer container produced by Rouge */
+.highlighter-rouge {
+  background-color: #2d2d2d;
+  color: #f8f8f2;
+  border-radius: 6px;
+  padding: 0.75em;
+  margin: 1em 0;
+  overflow-x: auto;
+}
+
+.highlighter-rouge pre,
+.highlighter-rouge code {
+  background: transparent;
+  color: inherit;
+  font-size: 0.9em;
 }
 
 


### PR DESCRIPTION
## Summary
- load Pygments monokai theme
- rename highlight class used for anchors
- style Rouge code blocks with dark background

## Testing
- `ruby -c validate.rb`

------
https://chatgpt.com/codex/tasks/task_e_685e591ec11c832494e2976fe9561057